### PR TITLE
[FIX] #85 解决站点健康提示：session_start()函数调用生成了一个PHP会话的问题

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -5,7 +5,9 @@
 function register_session()
 {
     if (!session_id()) {
-        session_start();
+        session_start([
+            'read_and_close' => true,
+        ]);
     }
 }
 


### PR DESCRIPTION
### 问题描述
#85 

### 自测

已在自己的站点测试过。

![image](https://user-images.githubusercontent.com/24445771/163672360-1e2df613-fbd6-4707-8e4d-0a64b3499b77.png)

![image](https://user-images.githubusercontent.com/24445771/163672388-db84f666-983e-4c00-9fdd-695a74480ff2.png)
