### PR TITLE
- 将 h2 标签修改为 h1 标签， 提升SEO爬网率

### DIFF
--- a/page.php
+++ b/page.php
@@ -6,7 +6,7 @@
             <div id="page-<?php the_ID() ?>" class="row row-cols-1">
                 <div id="post-main" class="col-lg-<?php pk_hide_sidebar_out('12','8') ?> col-md-12 <?php pk_open_box_animated('animated fadeInLeft') ?> ">
                     <div class="p-block">
-                        <div><h2 id="post-title" class="mb-0 puock-text t-xxl"><?php the_title() ?></h2></div>
+                        <div><h1 id="post-title" class="mb-0 puock-text t-xxl"><?php the_title() ?></h1></div>
                         <div class="options clearfix mt20">
                             <div class="float-left">
                                 <?php if (!pk_is_checked('hide_post_views')): ?>

--- a/single.php
+++ b/single.php
@@ -9,7 +9,7 @@
             <div id="post-main"
                  class="col-lg-<?php pk_hide_sidebar_out('12', '8') ?> col-md-12 <?php pk_open_box_animated('animated fadeInLeft') ?> ">
                 <div class="p-block">
-                    <div><h2 id="post-title" class="mb-0 puock-text t-xxl"><?php the_title() ?></h2></div>
+                    <div><h1 id="post-title" class="mb-0 puock-text t-xxl"><?php the_title() ?></h1></div>
                     <div class="options clearfix mt20">
                         <div class="float-left">
                             <?php if (!pk_is_checked('hide_post_views')): ?>


### PR DESCRIPTION
在做SEO优化时发现文章页中所有Title都为H2标签，而且没有H1标签，H1标签在很多SEO场景下爬虫都会有较高的权重，提高网站抓取效率。在经过测试后，发现更改为h1标签后并不会对样式表造成破坏。
目前这方面还在学习，不知道对不对，请大佬指教。