### PR TITLE
Update init.php

### DIFF
--- a/inc/init.php
+++ b/inc/init.php
@@ -103,7 +103,7 @@ function deel_setup()
 /**
  * Disable the emoji's
  */
-function disable_emojis()
+function pk_disable_emojis()
 {
     remove_action('wp_head', 'print_emoji_detection_script', 7);
     remove_action('admin_print_scripts', 'print_emoji_detection_script');
@@ -112,14 +112,14 @@ function disable_emojis()
     remove_filter('the_content_feed', 'wp_staticize_emoji');
     remove_filter('comment_text_rss', 'wp_staticize_emoji');
     remove_filter('wp_mail', 'wp_staticize_emoji_for_email');
-    add_filter('tiny_mce_plugins', 'disable_emojis_tinymce');
+    add_filter('tiny_mce_plugins', 'pk_disable_emojis_tinymce');
 }
 
-add_action('init', 'disable_emojis');
+add_action('init', 'pk_disable_emojis');
 /**
  * Filter function used to remove the tinymce emoji plugin.
  */
-function disable_emojis_tinymce($plugins)
+function pk_disable_emojis_tinymce($plugins)
 {
     if (is_array($plugins)) {
         return array_diff($plugins, array('wpemoji'));


### PR DESCRIPTION
修复和常用插件WP Githuber MD 存在的函数命名冲突，冲突提示信息片段：  `Fatal error: Cannot redeclare disable_emojis() (previously declared`