### PR TITLE
fix: 侧边栏缩略图鼠标悬浮变为直角

### DIFF
--- a/assets/style/style.less
+++ b/assets/style/style.less
@@ -1661,6 +1661,7 @@ a:hover {
     .img {
       flex-shrink: 0;
       margin-right: 10px;
+      border-radius: 3px;
       overflow: hidden;
 
       img {


### PR DESCRIPTION
当鼠标悬停时，侧边栏文章缩略图，放大之后，同时失去了圆角效果。

如果下图所示，① 箭头：鼠标悬停时为直角，② 箭头：正常情况下为 3px 圆角

网站：https://licoy.cn/

![20230108142630](https://user-images.githubusercontent.com/27202776/211183644-1e3ee7f9-682c-4687-800f-7d0514d6854c.png)
