### PR TITLE
🐛修复SEO关键词提示信息显示不全的问题

### DIFF
--- a/inc/fun/post-meta.php
+++ b/inc/fun/post-meta.php
@@ -8,7 +8,7 @@ PuockAbsMeta::newPostMeta('pk-post-seo', [
         array(
             "id" => "seo_keywords",
             "title" => "自定义SEO关键词",
-            'desc' => '多个关键词之间使用', '分隔，默认为设置的标签',
+            'desc' => '多个关键词之间使用", "分隔，默认为设置的标签',
             "type" => "text"
         ),
         array(


### PR DESCRIPTION
使用单引号时把后面的内容忽略了
![](https://user-images.githubusercontent.com/37013819/218297718-13cc70e0-693a-4807-8dc1-5826b3c5aae0.png)