### PR TITLE
Wpuock

### DIFF
--- a/pages/template-links.php
+++ b/pages/template-links.php
@@ -50,7 +50,11 @@ get_header();
                                     rel="<?php echo $link->link_rel ?>" title="<?php echo empty($link->link_notes) ? $link->link_name : $link->link_notes ?>"
                                    data-bs-toggle="tooltip">
                                     <div class="clearfix puock-bg">
-                                        <img <?php echo pk_get_lazy_img_info(pk_get_favicon_url($link->link_url),'md-avatar') ?> alt="<?php echo $link->link_name ?>">
+                                        <?php if (empty($link->link_image)) : ?>
+                                            <img <?php echo pk_get_lazy_img_info(pk_get_favicon_url($link->link_url),'md-avatar') ?> alt="<?php echo $link->link_name ?>">
+                                        <?php else :?>      
+                                            <img src="<?php echo $link->link_image ;?>"  alt="<?php echo $link->link_name ;?>" class="md-avatar" />
+                                        <?php endif;?>
                                         <div class="info">
                                             <p class="ml-1 text-nowrap text-truncate"><?php echo $link->link_name ?></p>
                                             <p class="c-sub ml-1 text-nowrap text-truncate"><?php echo empty($link->link_notes) ? '暂无介绍' : $link->link_notes ?></p>

--- a/pages/template-reads.php
+++ b/pages/template-reads.php
@@ -5,7 +5,7 @@ Template Name: 读者墙
 
 $year = 2;
 $sql = "SELECT count(comment_ID) as num, comment_author_email as mail,comment_author as `name`,comment_author_url as url
-                FROM $wpdb->comments WHERE user_id !=1 AND TO_DAYS(now()) - TO_DAYS(comment_date) < (".($year*365).")
+                FROM $wpdb->comments WHERE user_id !=1 AND comment_approved !=0 AND TO_DAYS(now()) - TO_DAYS(comment_date) < (".($year*365).")
                  group by comment_author_email order by num desc limit 0, 100";
 $reads = $wpdb->get_results($sql);
 get_header();


### PR DESCRIPTION
读者墙页面顶部区域显示读者列表时增添了评论是否通过审核的条件（comment_approved !=0），这样可以过滤未通过审核的评论者出现在此列表中