### PR TITLE
修改友情链接头像显示的问题

### DIFF
--- a/pages/template-links.php
+++ b/pages/template-links.php
@@ -50,7 +50,12 @@ get_header();
                                     rel="<?php echo $link->link_rel ?>" title="<?php echo empty($link->link_notes) ? $link->link_name : $link->link_notes ?>"
                                    data-bs-toggle="tooltip">
                                     <div class="clearfix puock-bg">
-                                        <img <?php echo pk_get_lazy_img_info(pk_get_favicon_url($link->link_url),'md-avatar') ?> alt="<?php echo $link->link_name ?>">
+                                        <?php if (!empty($link->link_image)) { ?>
+                                            <img <?php echo pk_get_lazy_img_info($link->link_image, 'md-avatar'); ?> alt="<?php echo $link->link_name; ?>">
+                                            <?php } else { ?>
+                                            <img <?php echo pk_get_lazy_img_info(pk_get_favicon_url($link->link_url), 'md-avatar'); ?> alt="<?php echo $link->link_name; ?>">
+                                            <?php } 
+                                        ?>
                                         <div class="info">
                                             <p class="ml-1 text-nowrap text-truncate"><?php echo $link->link_name ?></p>
                                             <p class="c-sub ml-1 text-nowrap text-truncate"><?php echo empty($link->link_notes) ? '暂无介绍' : $link->link_notes ?></p>


### PR DESCRIPTION
在后台新建链接的时候，虽然显示图片地址但是并不可以自定义展示头像。
<img width="1321" alt="image" src="https://user-images.githubusercontent.com/80749242/227899059-18801a96-b111-4a20-8a19-5cb2799b4779.png">

本次修改解决了这个问题，修改后的逻辑为：
 如果图片地址中自定义了头像链接则，则显示自定义的图片地址。 否则去获取网站图标 favicon.ico.