### PR TITLE
'${} string interpolation' is deprecated since PHP 8.2PHP(PHP6403)

### DIFF
--- a/inc/fun/opt.php
+++ b/inc/fun/opt.php
@@ -272,7 +272,7 @@ if (pk_is_checked('use_post_menu')) {
                 $start = stripos($content, $ms[0][$i]);
                 $end = strlen($ms[0][$i]);
                 $level = substr($ms[0][$i], 1, 2);
-                $content = substr_replace($content, "<$level id='pk-menu-${i}'>{$title}</{$level}>", $start, $end);
+                $content = substr_replace($content, "<$level id='pk-menu-{$i}'>{$title}</{$level}>", $start, $end);
             }
         }
         return $content;


### PR DESCRIPTION
'${} string interpolation' is deprecated since PHP 8.2PHP(PHP6403) Using ${} in strings is deprecated.intelephense(P1007) @var string|int $i