### PR TITLE
新增关闭友情页面选项

### DIFF
--- a/inc/setting/options/BaseOptionItem.php
+++ b/inc/setting/options/BaseOptionItem.php
@@ -28,6 +28,7 @@ abstract class BaseOptionItem
     {
         if(!self::$_link_category){
             self::$_link_category = get_all_category_id_row('link_category');
+            array_unshift(self::$_link_category, ['label' => '无', 'value' => '']);
         }
         return self::$_link_category;
     }
@@ -36,6 +37,7 @@ abstract class BaseOptionItem
     {
         if(!self::$_pages){
             $pages = array();
+            $pages[] = ['label' => '无', 'value' => ''];
             $pageObjects = get_pages('sort_column=post_parent,menu_order');
             foreach ($pageObjects as $page) {
                 $pages[] = ['label' => $page->post_title, 'value' => $page->ID];


### PR DESCRIPTION
修复主题配置里 友情链接页面 首页友情链接目录ID 选项只能开不能关的问题