### PR TITLE
✨新增作者页、标签页的描述，有利于seo

### DIFF
--- a/inc/seo.php
+++ b/inc/seo.php
@@ -47,6 +47,15 @@
 
     ?>
 <?php endif; ?>
+
+<?php if (is_author()) : ?>
+    <meta name="description" content="<?php echo the_author_meta('description') ?>"/>
+<?php endif; ?>
+
+<?php if (is_tag()) : ?>
+    <meta name="description" content="<?php echo preg_replace('/<[^>]*>/', '', tag_description()) ?>"/>
+<?php endif; ?>
+
 <?php
 if (is_home()) {
     echo '<link rel="canonical" href="' . home_url() . '">';
@@ -54,4 +63,3 @@ if (is_home()) {
     echo '<link rel="canonical" href="' . get_permalink() . '">';
 }
 ?>
-


### PR DESCRIPTION
## 1、作者页的description配置。
如作者cyunzing页面`https://www.xxxxx.com/author/cyunzing/` 的description配置，可在Wordpress后台“用户”->找到用户名为“cyunzing”->“个人说明”项进行编辑配置。

## 2、标签页的description配置。
如标签macos的页面`https://www.xxxxx.com/tag/macos/`的description配置，可在Wordpress后台“文章”->“标签”->找到标签为“macos”项进行编辑配置。
