### PR TITLE
✨后台主题配置新增友情链接排序选项

### DIFF
--- a/inc/seo.php
+++ b/inc/seo.php
@@ -47,6 +47,15 @@
 
     ?>
 <?php endif; ?>
+
+<?php if (is_author()) : ?>
+    <meta name="description" content="<?php echo the_author_meta('description') ?>"/>
+<?php endif; ?>
+
+<?php if (is_tag()) : ?>
+    <meta name="description" content="<?php echo preg_replace('/<[^>]*>/', '', tag_description()) ?>"/>
+<?php endif; ?>
+
 <?php
 if (is_home()) {
     echo '<link rel="canonical" href="' . home_url() . '">';
@@ -54,4 +63,3 @@ if (is_home()) {
     echo '<link rel="canonical" href="' . get_permalink() . '">';
 }
 ?>
-

--- a/inc/setting/options/BaseOptionItem.php
+++ b/inc/setting/options/BaseOptionItem.php
@@ -32,6 +32,39 @@ abstract class BaseOptionItem
         }
         return self::$_link_category;
     }
+    /**
+     * 获取友情链接排序顺序。
+     * 
+     * 升序 (ASC)、降序(DESC)，默认为升序 (ASC)。
+     * https://developer.wordpress.org/reference/functions/get_bookmarks/#parameters
+     * 
+     */
+    protected static function get_link_order()
+    {
+        return [
+            ["label"=>"升序 (ASC)","value"=>"ASC"],
+            ["label"=>"降序(DESC)","value"=>"DESC"]
+        ];
+    }
+
+    /**
+     * 获取友情链接排序字段。
+     * 
+     * 下面仅为部分字段，所支持的全部字段请查看官方文档`orderby`部分
+     * https://developer.wordpress.org/reference/functions/get_bookmarks/#parameters
+     * 
+     */
+    protected static function get_link_order_by()
+    {
+        return [
+            ["label"=>"ID排序","value"=>"link_id"],
+            ["label"=>"链接排序","value"=>"url"],
+            ["label"=>"名字排序","value"=>"name"],
+            ["label"=>"评级排序","value"=>"rating"],
+            ["label"=>"长度排序","value"=>"length"],
+            ["label"=>"随机排序","value"=>"rand"]
+        ];
+    }
 
     protected static function get_pages()
     {

--- a/inc/setting/options/OptionBasic.php
+++ b/inc/setting/options/OptionBasic.php
@@ -208,6 +208,20 @@ class OptionBasic extends BaseOptionItem
                     'options' => self::get_link_category(),
                 ],
                 [
+                    'id' => 'index_link_order_by',
+                    'label' => __('首页友情链接排序字段', PUOCK),
+                    'tips' => __('根据链接字段进行排序，缺省默认值为ID排序', PUOCK),
+                    'type' => 'select',
+                    'options' => self::get_link_order_by(),
+                ],
+                [
+                    'id' => 'index_link_order',
+                    'label' => __('首页友情链接排序顺序', PUOCK),
+                    'tips' => __('缺省默认值为升序 (ASC)', PUOCK),
+                    'type' => 'select',
+                    'options' => self::get_link_order(),
+                ],
+                [
                     'id' => 'gravatar_url',
                     'label' => __('Gravatar头像源', PUOCK),
                     'type' => 'radio',

--- a/templates/module-links.php
+++ b/templates/module-links.php
@@ -14,6 +14,8 @@ if (!empty($link_cid)):
             if(!$links){
                 $links = get_bookmarks(array(
                     'category' => $link_cid,
+                    'orderby' => 'rating',  //  根据Wordpress链接中评级进行排序。
+                    'order' => 'DESC',      //  ASC：升序排列（缺省默认值）、DESC：降序排列。
                     'category_before' => '',
                     'title_li' => '',
                     'echo' => 0,

--- a/templates/module-links.php
+++ b/templates/module-links.php
@@ -12,10 +12,12 @@ if (!empty($link_cid)):
             <?php
             $links = pk_cache_get(PKC_FOOTER_LINKS);
             if(!$links){
+                $order = pk_get_option('index_link_order', 'ASC');
+                $orderby = pk_get_option('index_link_order_by', 'link_id');
                 $links = get_bookmarks(array(
                     'category' => $link_cid,
-                    'orderby' => 'rating',  //  根据Wordpress链接中评级进行排序。
-                    'order' => 'DESC',      //  ASC：升序排列（缺省默认值）、DESC：降序排列。
+                    'orderby' => $orderby,
+                    'order' => $order,
                     'category_before' => '',
                     'title_li' => '',
                     'echo' => 0,


### PR DESCRIPTION
### 新增内容

1. 主题配置->基础设置新增`首页友情链接排序字段`、`首页友情链接排序顺序`选项。
![image](https://github.com/user-attachments/assets/0dca2f5a-86b9-4372-ac3a-df3e187ebf7b)

两个选项的取值可参考Wordpress文档：[https://developer.wordpress.org/reference/functions/get_bookmarks/#parameters](https://developer.wordpress.org/reference/functions/get_bookmarks/#parameters)

2. `首页友情链接排序字段`选项
值对应wordpress文档`orderby `选项的值，默认可以选择以下几个选项（有需要可以自行增加）：
- `ID排序`即：link_id；
- `链接排序`即：url；
- `名称排序`即：name；
- `评级排序`即：rating；
- `长度排序`即：length；
- `随机排序`即：rand；

3. `首页友情链接排序顺序`选项
值对应wordpress文档`order `选项的值。
- `升序 (ASC)`即：ASC；
- `降序(DESC)`即：DESC