### PR TITLE
fix: 修复文章仅存在pingback引用时布局异常的问题

### DIFF
--- a/comments.php
+++ b/comments.php
@@ -126,12 +126,15 @@
         <?php endif; ?>
         <div id="post-comments">
             <?php
-            if (get_comments_number() > 0):
+            if (have_comments()):
                 wp_list_comments(array(
                     'type' => 'comment',
                     'callback' => 'pk_comment_callback',
                 ));
-                echo '</div>';
+
+                if (isset($GLOBALS['pk_comment_callback_cur_id'])) {
+                    echo '</div>';
+                }
             endif;
             ?>
 


### PR DESCRIPTION
如题，当仅存在 ping 引用时，由于 wp_list_comments 限制了 type 为 comment，pk_comment_callback 返回的内容为空，导致多了一个 div 标签，侧栏会错位掉到底部
