### PR TITLE
fix: prevent SSRF in favicon proxy by blocking private/internal IPs

### DIFF
--- a/inc/favicon.php
+++ b/inc/favicon.php
@@ -12,6 +12,15 @@ function pk_get_website_favicon_ico($url, $cache_time, $default_ico, $basename =
             return;
         }
     }
+    // SSRF protection: block requests to private/internal IPs
+    $parsed_url = parse_url($url);
+    $host = $parsed_url['host'] ?? '';
+    $resolved_ip = gethostbyname($host);
+    if ($resolved_ip === $host || filter_var($resolved_ip, FILTER_VALIDATE_IP, FILTER_FLAG_NO_PRIV_RANGE | FILTER_FLAG_NO_RES_RANGE | FILTER_FLAG_NO_LOOPBACK) === false) {
+        pk_favicon_put_default_and_output($cache_file, $cache_filename, $default_ico);
+        return;
+    }
+
     $ch = curl_init($url . '/' . $basename);
     $ico_file = fopen($cache_file, 'w');
     curl_setopt($ch, CURLOPT_CONNECTTIMEOUT, 2);


### PR DESCRIPTION
## Summary

Prevent SSRF in the favicon proxy by blocking requests to private/internal IP addresses.

## Problem

`inc/favicon.php` fetches user-supplied URLs via `curl_init($_GET['url'] . '/favicon.ico')`:

```php
$url = @$_GET['url'];
pk_get_website_favicon_ico($url, ...);
// Inside:
$ch = curl_init($url . '/' . $basename);
curl_exec($ch);
```

No validation that the URL doesn't point to internal services. An attacker can:
- Scan internal network: `?url=http://192.168.1.1`
- Access cloud metadata: `?url=http://169.254.169.254/latest`
- Probe internal services for response timing

## Fix

Added IP validation using PHP's `filter_var` with `FILTER_FLAG_NO_PRIV_RANGE | FILTER_FLAG_NO_RES_RANGE | FILTER_FLAG_NO_LOOPBACK` before making the curl request.

## Impact

- **Type**: Server-Side Request Forgery (CWE-918)
- **Affected endpoint**: `inc/favicon.php`
- **Risk**: Internal network scanning, cloud credential theft
- **OWASP**: A10:2021 — Server-Side Request Forgery